### PR TITLE
Flexible path

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"path/filepath"
 
 	"github.com/bitrise-io/go-steputils/stepconf"
 	"github.com/bitrise-io/go-utils/log"
@@ -73,8 +74,9 @@ func main() {
 			}
 		}
 		if build.Status != 0 {
-			if strings.TrimSpace(cfg.BuildArtifactsSavePath) != "" {
-				fullBuildArtifactsSavePath := strings.TrimSuffix(cfg.BuildArtifactsSavePath, "/") + "/"
+			buildArtifactSaveDir := strings.TrimSpace(cfg.BuildArtifactsSavePath)
+			if buildArtifactSaveDir != "" {
+				fullBuildArtifactsSavePath := strings.TrimSpace(cfg.BuildArtifactsSavePath, "/")
 				artifactsResponse, err := build.GetBuildArtifacts(app)
 				if err != nil {
 					log.Warnf("failed to get build artifacts, error: %s", err)
@@ -85,7 +87,8 @@ func main() {
 						log.Warnf("failed to get build artifact, error: %s", err)
 					}
 
-					downloadErr := artifactObj.Artifact.DownloadArtifact(strings.TrimSpace(fullBuildArtifactsSavePath) + artifactObj.Artifact.Title)
+					fullBuildArtifactsSavePath := filepath.Join(buildArtifactSaveDir, artifactObj.Artifact.Title)
+					downloadErr := artifactObj.Artifact.DownloadArtifact(fullBuildArtifactsSavePath)
 					if downloadErr != nil {
 						log.Warnf("failed to download artifact, error: %s", downloadErr)
 					}

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func main() {
 		}
 		if build.Status != 0 {
 			if strings.TrimSpace(cfg.BuildArtifactsSavePath) != "" {
-				fullBuildArtifactsSavePath := strings.trimSuffix(cfg.BuildArtifactsSavePath, "/") + "/"
+				fullBuildArtifactsSavePath := strings.TrimSuffix(cfg.BuildArtifactsSavePath, "/") + "/"
 				artifactsResponse, err := build.GetBuildArtifacts(app)
 				if err != nil {
 					log.Warnf("failed to get build artifacts, error: %s", err)

--- a/main.go
+++ b/main.go
@@ -76,7 +76,6 @@ func main() {
 		if build.Status != 0 {
 			buildArtifactSaveDir := strings.TrimSpace(cfg.BuildArtifactsSavePath)
 			if buildArtifactSaveDir != "" {
-				fullBuildArtifactsSavePath := strings.TrimSpace(cfg.BuildArtifactsSavePath, "/")
 				artifactsResponse, err := build.GetBuildArtifacts(app)
 				if err != nil {
 					log.Warnf("failed to get build artifacts, error: %s", err)

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ func main() {
 		}
 		if build.Status != 0 {
 			if strings.TrimSpace(cfg.BuildArtifactsSavePath) != "" {
+				fullBuildArtifactsSavePath := strings.trimSuffix(cfg.BuildArtifactsSavePath, "/") + "/"
 				artifactsResponse, err := build.GetBuildArtifacts(app)
 				if err != nil {
 					log.Warnf("failed to get build artifacts, error: %s", err)
@@ -84,11 +85,11 @@ func main() {
 						log.Warnf("failed to get build artifact, error: %s", err)
 					}
 
-					downloadErr := artifactObj.Artifact.DownloadArtifact(strings.TrimSpace(cfg.BuildArtifactsSavePath) + artifactObj.Artifact.Title)
+					downloadErr := artifactObj.Artifact.DownloadArtifact(strings.TrimSpace(fullBuildArtifactsSavePath) + artifactObj.Artifact.Title)
 					if downloadErr != nil {
 						log.Warnf("failed to download artifact, error: %s", downloadErr)
 					}
-					log.Donef("Downloaded: " + artifactObj.Artifact.Title + " to path " + strings.TrimSpace(cfg.BuildArtifactsSavePath))
+					log.Donef("Downloaded: " + artifactObj.Artifact.Title + " to path " + strings.TrimSpace(fullBuildArtifactsSavePath))
 				}
 			}
 		}


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires PATCH [version update](https://semver.org/)

### Context

<!--- One sentence summary on why the change is needed. -->

build_artifacts_save_path isn't smart about a missing trailing slash.
Say I provide /path/to/dir as my save path. The step will save artifact.file to /path/to/dirartifact.file

This is inconvenient because the common input is $BITRISE_DEPLOY_DIR, which, by default, lacks a trailing slash.

<!-- Please link the issue that the PR fixes.
Resolves: https://github.com/bitrise-steplib/bitrise-step-build-router-wait/compare/master...benbitrise:flexible_path?expand=1
-->

### Changes

<!-- 
- ensures there is a trailing suffix on all `build_artifacts_save_path` values. Adds one if there's not one.
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions
